### PR TITLE
Bump Cert-manager Helm chart to v1.11.0

### DIFF
--- a/cert-manager/install.sh
+++ b/cert-manager/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml

--- a/cert-manager/manifest.yaml
+++ b/cert-manager/manifest.yaml
@@ -1,7 +1,6 @@
----
 name: cert-manager
 title: "Cert Manager"
-version: v1.5.3
+version: v1.11.0
 maintainer: alex@openfaas.com
 description: cert-manager is a native Kubernetes certificate management controller
 url: https://cert-manager.io/docs/release-notes/release-notes-1.0/


### PR DESCRIPTION



<Actions>
    <action id="7e3d5fd49a4ff488fbd913bb9468f65ef34e3cc369554544dfad86ce611abc86">
        <h2>Bump Cert-manager Helm chart to v1.11.0</h2>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update cert-manager/manifest.yaml</summary>
            <details>
                <summary>v1.11.0</summary>
                <code>&#xA;Release published on the 2023-01-11 17:07:28 +0000 UTC at the url https://github.com/cert-manager/cert-manager/releases/tag/v1.11.0&#xA;&#xA;cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;`v1.11.0` includes a drastic reduction in cert-manager&#39;s runtime memory usage, a slew of improvements to AKS integrations and various other tweaks, fixes and improvements, all towards cert-manager&#39;s goal of being the best way to handle certificates in modern Cloud Native applications.&#xD;&#xA;&#xD;&#xA;## Community&#xD;&#xA;&#xD;&#xA;Thanks again to all open-source contributors with commits in this release, including:&#xD;&#xA;&#xD;&#xA;- @cmcga1125&#xD;&#xA;- @karlschriek&#xD;&#xA;- @lvyanru8200&#xD;&#xA;- @mmontes11&#xD;&#xA;- @pinkfloydx33&#xD;&#xA;- @sathyanarays&#xD;&#xA;- @weisdd&#xD;&#xA;- @yann-soubeyrand&#xD;&#xA;- @joycebrum&#xD;&#xA;- @Git-Jiro&#xD;&#xA;- @thib-mary&#xD;&#xA;- @yk&#xD;&#xA;- @RomanenkoDenys&#xD;&#xA;- @lucacome&#xD;&#xA;- @yanggangtony&#xD;&#xA;&#xD;&#xA;Thanks also to the following cert-manager maintainers for their contributions during this release:&#xD;&#xA;&#xD;&#xA;- @wallrj &#xD;&#xA;- @irbekrm &#xD;&#xA;- @maelvls &#xD;&#xA;- @SgtCoDFish &#xD;&#xA;- @inteon &#xD;&#xA;- @jakexks &#xD;&#xA;- @JoshVanL &#xD;&#xA;&#xD;&#xA;Thanks also to the [CNCF](https://www.cncf.io/), which provides resources and support, and to the AWS open source team for being good community members and for their maintenance of the [PrivateCA Issuer](https://github.com/cert-manager/aws-privateca-issuer).&#xD;&#xA;&#xD;&#xA;In addition, massive thanks to [Jetstack](https://www.jetstack.io/) (by [Venafi](https://www.venafi.com/)) for contributing developer time and resources towards the continued maintenance of cert-manager projects.&#xD;&#xA;&#xD;&#xA;## Changes since cert-manager `v1.10`&#xD;&#xA;&#xD;&#xA;For an overview of new features, see the [v1.11 release notes](https://cert-manager.io/docs/release-notes/release-notes-1.11/)!&#xD;&#xA;&#xD;&#xA;### Feature&#xD;&#xA;&#xD;&#xA;- Helm: allow configuring the image used by ACME HTTP-01 solver (#5554, @yann-soubeyrand)&#xD;&#xA;- Add the `--max-concurrent-challenges` controller flag to the helm chart (#5638, @lvyanru8200)&#xD;&#xA;- Adds the ability to specify a custom CA bundle in Issuers when connecting to an ACME server (#5644, @SgtCoDFish)&#xD;&#xA;- Enable testing against Kubernetes 1.26 and test with Kubernetes 1.26 by default (#5646, @SgtCoDFish)&#xD;&#xA;- Experimental make targets for pushing images to an OCI registry using `ko` and redeploying cert-manager to the cluster referenced by your current KUBECONFIG context. (#5655, @wallrj)&#xD;&#xA;- Add ability to run acmesolver pods as root if desired. The default is still to run as non-root. (#5546, @cmcga1125)&#xD;&#xA;- Add support for DC and UID in `LiteralSubject` field, all mandatory OIDs are now supported for LDAP certificates (rfc4514). (#5587, @SpectralHiss)&#xD;&#xA;- Add support for Workload Identity to AzureDNS resolver (#5570, @weisdd)&#xD;&#xA;- Breaking: updates the gateway API integration to use the more stable v1beta1 API version. Any users of the cert-manager `ExperimentalGatewayAPISupport` alpha feature must ensure that `v1beta` of Gateway API is installed in cluster. (#5583, @lvyanru8200)&#xD;&#xA;- Certificate secrets get refreshed if the keystore format change (#5597, @sathyanarays)&#xD;&#xA;- Introducing UseCertificateRequestBasicConstraints feature flag to enable Basic Constraints in the Certificate Signing Request (#5552, @sathyanarays)&#xD;&#xA;- Return error when Gateway has a cross-namespace secret ref (#5613, @mmontes11)&#xD;&#xA;- Signers fire an event on CertificateRequests which have not been approved yet. Used for informational purposes so users understand why a request is not progressing. (#5535, @JoshVanL)&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- Don&#39;t log errors relating to self-signed issuer checks for external issuers (#5681, @SgtCoDFish)&#xD;&#xA;- Fixed a bug in AzureDNS resolver that led to early reconciliations in misconfigured Workload Identity-enabled setups (when Federated Identity Credential is not linked with a controller&#39;s k8s service account) (#5663, @weisdd)&#xD;&#xA;- Use manually specified temporary directory template when verifying CRDs (#5680, @SgtCoDFish)&#xD;&#xA;- `vcert` was upgraded to `v4.23.0`, fixing two bugs in cert-manager. The first bug was preventing the Venafi issuer from renewing certificates when using TPP has been fixed. You should no longer see your certificates getting stuck with `WebSDK CertRequest Module Requested Certificate` or `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`. The second bug that was fixed prevented the use of `algorithm: Ed25519` in Certificate resources with VaaS. (#5674, @maelvls)&#xD;&#xA;- Upgrade `golang/x/net` to fix CVE-2022-41717 (#5632, @SgtCoDFish)&#xD;&#xA;- Bug fix: When using feature gates with the helm chart, enable feature gate flags on webhook as well as controller (#5584, @lvyanru8200)&#xD;&#xA;- Fix `golang.org/x/text` vulnerability (#5562, @SgtCoDFish)&#xD;&#xA;- Fixes a bug that caused the Vault issuer to omit the Vault namespace in requests to the Vault API. (#5591, @wallrj)&#xD;&#xA;- The Venafi Issuer now supports TLS 1.2 renegotiation, so that it can connect to TPP servers where the vedauth API endpoints are configured to *accept* client certificates. (Note: This does not mean that the Venafi Issuer supports client certificate authentication). (#5568, @wallrj)&#xD;&#xA;- Upgrade to go 1.19.4 to fix CVE-2022-41717 (#5619, @SgtCoDFish)&#xD;&#xA;- Upgrade to latest go minor release (#5559, @SgtCoDFish)&#xD;&#xA;- Ensure `extraArgs` in Helm takes precedence over the new acmesolver image options (#5702, @SgtCoDFish)&#xD;&#xA;- Fix cainjector&#39;s --namespace flag. Users who want to prevent cainjector from reading all Secrets and Certificates in all namespaces (i.e to prevent excessive memory consumption) can now scope it to a single namespace using the --namespace flag. A cainjector that is only used as part of cert-manager installation only needs access to the cert-manager installation namespace. (#5694, @irbekrm)&#xD;&#xA;- Fixes a bug where cert-manager controller was caching all Secrets twice (#5691, @irbekrm)&#xD;&#xA;&#xD;&#xA;### Other&#xD;&#xA;&#xD;&#xA;- `certificate.spec.secretName` Secrets will now be labelled with the `controller.cert-manager.io/fao` label (#5703, @irbekrm)&#xD;&#xA;- Upgrade to go 1.19.5 (#5714, @yanggangtony)&#xD;&#xA;&#xD;&#xA;### Known issues&#xD;&#xA;- There is a bug in conformance tests for external DNS webhook implementations that was introduced in this release, see https://github.com/cert-manager/cert-manager/issues/5725&#xD;&#xA;If you are importing cert-manager as a library to run conformance tests against your DNS webhook solver implementation, please make sure that you import a version with a fix, see https://github.com/cert-manager/cert-manager/issues/5725#issuecomment-1397245757</code>
            </details>
        </details>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update cert-manager/manifest.yaml</summary>
            <details>
                <summary>v1.11.0</summary>
                <code>&#xA;Release published on the 2023-01-11 17:07:28 +0000 UTC at the url https://github.com/cert-manager/cert-manager/releases/tag/v1.11.0&#xA;&#xA;cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;`v1.11.0` includes a drastic reduction in cert-manager&#39;s runtime memory usage, a slew of improvements to AKS integrations and various other tweaks, fixes and improvements, all towards cert-manager&#39;s goal of being the best way to handle certificates in modern Cloud Native applications.&#xD;&#xA;&#xD;&#xA;## Community&#xD;&#xA;&#xD;&#xA;Thanks again to all open-source contributors with commits in this release, including:&#xD;&#xA;&#xD;&#xA;- @cmcga1125&#xD;&#xA;- @karlschriek&#xD;&#xA;- @lvyanru8200&#xD;&#xA;- @mmontes11&#xD;&#xA;- @pinkfloydx33&#xD;&#xA;- @sathyanarays&#xD;&#xA;- @weisdd&#xD;&#xA;- @yann-soubeyrand&#xD;&#xA;- @joycebrum&#xD;&#xA;- @Git-Jiro&#xD;&#xA;- @thib-mary&#xD;&#xA;- @yk&#xD;&#xA;- @RomanenkoDenys&#xD;&#xA;- @lucacome&#xD;&#xA;- @yanggangtony&#xD;&#xA;&#xD;&#xA;Thanks also to the following cert-manager maintainers for their contributions during this release:&#xD;&#xA;&#xD;&#xA;- @wallrj &#xD;&#xA;- @irbekrm &#xD;&#xA;- @maelvls &#xD;&#xA;- @SgtCoDFish &#xD;&#xA;- @inteon &#xD;&#xA;- @jakexks &#xD;&#xA;- @JoshVanL &#xD;&#xA;&#xD;&#xA;Thanks also to the [CNCF](https://www.cncf.io/), which provides resources and support, and to the AWS open source team for being good community members and for their maintenance of the [PrivateCA Issuer](https://github.com/cert-manager/aws-privateca-issuer).&#xD;&#xA;&#xD;&#xA;In addition, massive thanks to [Jetstack](https://www.jetstack.io/) (by [Venafi](https://www.venafi.com/)) for contributing developer time and resources towards the continued maintenance of cert-manager projects.&#xD;&#xA;&#xD;&#xA;## Changes since cert-manager `v1.10`&#xD;&#xA;&#xD;&#xA;For an overview of new features, see the [v1.11 release notes](https://cert-manager.io/docs/release-notes/release-notes-1.11/)!&#xD;&#xA;&#xD;&#xA;### Feature&#xD;&#xA;&#xD;&#xA;- Helm: allow configuring the image used by ACME HTTP-01 solver (#5554, @yann-soubeyrand)&#xD;&#xA;- Add the `--max-concurrent-challenges` controller flag to the helm chart (#5638, @lvyanru8200)&#xD;&#xA;- Adds the ability to specify a custom CA bundle in Issuers when connecting to an ACME server (#5644, @SgtCoDFish)&#xD;&#xA;- Enable testing against Kubernetes 1.26 and test with Kubernetes 1.26 by default (#5646, @SgtCoDFish)&#xD;&#xA;- Experimental make targets for pushing images to an OCI registry using `ko` and redeploying cert-manager to the cluster referenced by your current KUBECONFIG context. (#5655, @wallrj)&#xD;&#xA;- Add ability to run acmesolver pods as root if desired. The default is still to run as non-root. (#5546, @cmcga1125)&#xD;&#xA;- Add support for DC and UID in `LiteralSubject` field, all mandatory OIDs are now supported for LDAP certificates (rfc4514). (#5587, @SpectralHiss)&#xD;&#xA;- Add support for Workload Identity to AzureDNS resolver (#5570, @weisdd)&#xD;&#xA;- Breaking: updates the gateway API integration to use the more stable v1beta1 API version. Any users of the cert-manager `ExperimentalGatewayAPISupport` alpha feature must ensure that `v1beta` of Gateway API is installed in cluster. (#5583, @lvyanru8200)&#xD;&#xA;- Certificate secrets get refreshed if the keystore format change (#5597, @sathyanarays)&#xD;&#xA;- Introducing UseCertificateRequestBasicConstraints feature flag to enable Basic Constraints in the Certificate Signing Request (#5552, @sathyanarays)&#xD;&#xA;- Return error when Gateway has a cross-namespace secret ref (#5613, @mmontes11)&#xD;&#xA;- Signers fire an event on CertificateRequests which have not been approved yet. Used for informational purposes so users understand why a request is not progressing. (#5535, @JoshVanL)&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- Don&#39;t log errors relating to self-signed issuer checks for external issuers (#5681, @SgtCoDFish)&#xD;&#xA;- Fixed a bug in AzureDNS resolver that led to early reconciliations in misconfigured Workload Identity-enabled setups (when Federated Identity Credential is not linked with a controller&#39;s k8s service account) (#5663, @weisdd)&#xD;&#xA;- Use manually specified temporary directory template when verifying CRDs (#5680, @SgtCoDFish)&#xD;&#xA;- `vcert` was upgraded to `v4.23.0`, fixing two bugs in cert-manager. The first bug was preventing the Venafi issuer from renewing certificates when using TPP has been fixed. You should no longer see your certificates getting stuck with `WebSDK CertRequest Module Requested Certificate` or `This certificate cannot be processed while it is in an error state. Fix any errors, and then click Retry.`. The second bug that was fixed prevented the use of `algorithm: Ed25519` in Certificate resources with VaaS. (#5674, @maelvls)&#xD;&#xA;- Upgrade `golang/x/net` to fix CVE-2022-41717 (#5632, @SgtCoDFish)&#xD;&#xA;- Bug fix: When using feature gates with the helm chart, enable feature gate flags on webhook as well as controller (#5584, @lvyanru8200)&#xD;&#xA;- Fix `golang.org/x/text` vulnerability (#5562, @SgtCoDFish)&#xD;&#xA;- Fixes a bug that caused the Vault issuer to omit the Vault namespace in requests to the Vault API. (#5591, @wallrj)&#xD;&#xA;- The Venafi Issuer now supports TLS 1.2 renegotiation, so that it can connect to TPP servers where the vedauth API endpoints are configured to *accept* client certificates. (Note: This does not mean that the Venafi Issuer supports client certificate authentication). (#5568, @wallrj)&#xD;&#xA;- Upgrade to go 1.19.4 to fix CVE-2022-41717 (#5619, @SgtCoDFish)&#xD;&#xA;- Upgrade to latest go minor release (#5559, @SgtCoDFish)&#xD;&#xA;- Ensure `extraArgs` in Helm takes precedence over the new acmesolver image options (#5702, @SgtCoDFish)&#xD;&#xA;- Fix cainjector&#39;s --namespace flag. Users who want to prevent cainjector from reading all Secrets and Certificates in all namespaces (i.e to prevent excessive memory consumption) can now scope it to a single namespace using the --namespace flag. A cainjector that is only used as part of cert-manager installation only needs access to the cert-manager installation namespace. (#5694, @irbekrm)&#xD;&#xA;- Fixes a bug where cert-manager controller was caching all Secrets twice (#5691, @irbekrm)&#xD;&#xA;&#xD;&#xA;### Other&#xD;&#xA;&#xD;&#xA;- `certificate.spec.secretName` Secrets will now be labelled with the `controller.cert-manager.io/fao` label (#5703, @irbekrm)&#xD;&#xA;- Upgrade to go 1.19.5 (#5714, @yanggangtony)&#xD;&#xA;&#xD;&#xA;### Known issues&#xD;&#xA;- There is a bug in conformance tests for external DNS webhook implementations that was introduced in this release, see https://github.com/cert-manager/cert-manager/issues/5725&#xD;&#xA;If you are importing cert-manager as a library to run conformance tests against your DNS webhook solver implementation, please make sure that you import a version with a fix, see https://github.com/cert-manager/cert-manager/issues/5725#issuecomment-1397245757</code>
            </details>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update cert-manager/install.sh</summary>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update cert-manager/install.sh</summary>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, next it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [https://matrix.to/#/#Updatecli_community:gitter.im](chat)
