### PR TITLE
Bump Keda Helm chart to 2.10.1

### DIFF
--- a/keda/install.sh
+++ b/keda/install.sh
@@ -5,4 +5,4 @@ helm repo update
 
 kubectl create namespace keda
 
-helm install keda kedacore/keda --version 2.9.2 --namespace keda
+helm install keda kedacore/keda --version 2.9.4 --namespace keda

--- a/keda/install.sh
+++ b/keda/install.sh
@@ -5,4 +5,4 @@ helm repo update
 
 kubectl create namespace keda
 
-helm install keda kedacore/keda --version 2.9.4 --namespace keda
+helm install keda kedacore/keda --version 2.10.1 --namespace keda

--- a/keda/manifest.yaml
+++ b/keda/manifest.yaml
@@ -1,7 +1,6 @@
----
 name: keda
 title: "KEDA"
-version: "2.9.2"
+version: "2.9.3"
 maintainer: engin.diri@pulumi.com
 description: KEDA is a Kubernetes-based Event Driven Autoscaler. With KEDA, you can scale any container in Kubernetes based on the number of events needing to be processed.
 url: https://keda.sh/

--- a/keda/manifest.yaml
+++ b/keda/manifest.yaml
@@ -1,6 +1,6 @@
 name: keda
 title: "KEDA"
-version: "2.9.3"
+version: "2.10.0"
 maintainer: engin.diri@pulumi.com
 description: KEDA is a Kubernetes-based Event Driven Autoscaler. With KEDA, you can scale any container in Kubernetes based on the number of events needing to be processed.
 url: https://keda.sh/


### PR DESCRIPTION



<Actions>
    <action id="a6c0b398d41fd187d198759e71a70ea0c906a86f537a1505648a79e41c790ef2">
        <h2>Bump Keda Helm chart to 2.10.1</h2>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update keda/manifest.yaml</summary>
            <details>
                <summary>2.10.0</summary>
                <code>&#xA;Release published on the 2023-03-09 19:42:35 +0000 UTC at the url https://github.com/kedacore/keda/releases/tag/v2.10.0&#xA;&#xA;We are happy to release KEDA 2.10.0 🎉&#xD;&#xA;&#xD;&#xA;Here are some highlights:&#xD;&#xA;&#xD;&#xA;- New ArangoDB Scaler&#xD;&#xA;- New (experimental) GitHub Actions Scaler&#xD;&#xA;- New admission webhook for validating ScaledObjects&#xD;&#xA;- Security enhancements thanks to certificate integrations&#xD;&#xA;- Support for custom CAs&#xD;&#xA;&#xD;&#xA;Here are the new deprecation(s) as of this release:&#xD;&#xA;- **General**: Deprecate explicitly setting `metricName` field from `ScaledObject.triggers[*].metadata` ([#4220](https://github.com/kedacore/keda/issues/4220))&#xD;&#xA;- **Prometheus Scaler**: `cortexOrgId` metadata deprecated in favor of custom headers ([#4208](https://github.com/kedacore/keda/issues/4208))&#xD;&#xA;&#xD;&#xA;Learn how to deploy KEDA by reading [our documentation](https://keda.sh/docs/2.10/deploy/).&#xD;&#xA;&#xD;&#xA;🗓️ The next KEDA release is currently being estimated for June 13th, learn more in our [roadmap](https://github.com/kedacore/keda/blob/main/ROADMAP.md#upcoming-release-cycles).&#xD;&#xA;&#xD;&#xA;### New&#xD;&#xA;&#xD;&#xA;Here is an overview of all **stable** additions:&#xD;&#xA;&#xD;&#xA;- **General**: Add support to register custom CAs globally in KEDA operator ([#4168](https://github.com/kedacore/keda/issues/4168))&#xD;&#xA;- **General**: Introduce admission webhooks to automatically validate resource changes to prevent misconfiguration and enforce best practices ([#3755](https://github.com/kedacore/keda/issues/3755))&#xD;&#xA;- **General**: Introduce new ArangoDB Scaler ([#4000](https://github.com/kedacore/keda/issues/4000))&#xD;&#xA;- **Prometheus Metrics**: Introduce scaler activity in Prometheus metrics ([#4114](https://github.com/kedacore/keda/issues/4114))&#xD;&#xA;- **Prometheus Metrics**: Introduce scaler latency in Prometheus metrics ([#4037](https://github.com/kedacore/keda/issues/4037))&#xD;&#xA;- **Prometheus Scaler**: Extend Prometheus Scaler to support Azure managed service for Prometheus ([#4153](https://github.com/kedacore/keda/issues/4153))&#xD;&#xA;&#xD;&#xA;Here is an overview of all new **experimental** features:&#xD;&#xA;&#xD;&#xA;- **GitHub Scaler**: Introduced new GitHub Scaler (#1732)&#xD;&#xA;&#xD;&#xA;### Improvements&#xD;&#xA;&#xD;&#xA;- **General**: Add a warning when KEDA run outside supported k8s versions ([#4130](https://github.com/kedacore/keda/issues/4130))&#xD;&#xA;- **General**: Use (self-signed) certificates for all the communications (internals and externals) ([#3931](https://github.com/kedacore/keda/issues/3931))&#xD;&#xA;- **General**: Use TLS1.2 as minimum TLS version ([#4193](https://github.com/kedacore/keda/issues/4193))&#xD;&#xA;- **Azure Application Insights Scaler**: Add ignoreNullValues to ignore errors when the data returned has null in its values ([#4316](https://github.com/kedacore/keda/issues/4316))&#xD;&#xA;- **Azure Pipelines Scaler**: Improve error logging for `validatePoolID` ([#3996](https://github.com/kedacore/keda/issues/3996))&#xD;&#xA;- **Azure Pipelines Scaler**: New configuration parameter `requireAllDemands` to scale only if jobs request all demands provided by the scaling definition ([#4138](https://github.com/kedacore/keda/issues/4138))&#xD;&#xA;- **Hashicorp Vault**: Add support to secrets backend version 1 ([#2645](https://github.com/kedacore/keda/issues/2645))&#xD;&#xA;- **Kafka Scaler**: Add support to use `tls` and `sasl` in ScaledObject ([#4232](https://github.com/kedacore/keda/issues/4322))&#xD;&#xA;- **Kafka Scaler**: Improve error logging for `GetBlock` method ([#4232](https://github.com/kedacore/keda/issues/4232))&#xD;&#xA;- **Prometheus Scaler**: Add custom headers and custom auth support ([#4208](https://github.com/kedacore/keda/issues/4208))&#xD;&#xA;- **RabbitMQ Scaler**:  Add TLS support ([#967](https://github.com/kedacore/keda/issues/967))&#xD;&#xA;- **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))&#xD;&#xA;- **Selenium Grid Scaler**: Add `platformName` to selenium-grid scaler metadata structure ([#4038](https://github.com/kedacore/keda/issues/4038))&#xD;&#xA;&#xD;&#xA;### Fixes&#xD;&#xA;&#xD;&#xA;- **General**: Fix regression in fallback mechanism ([#4249](https://github.com/kedacore/keda/issues/4249))&#xD;&#xA;- **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))&#xD;&#xA;- **AWS Cloudwatch Scaler:** Make `metricName` and `namespace` optional when using `expression` ([#4334](https://github.com/kedacore/keda/issues/4262))&#xD;&#xA;- **Azure Pipelines Scaler**: Add new parameter to limit the jobs returned ([#4324](https://github.com/kedacore/keda/issues/4324))&#xD;&#xA;- **Azure Queue Scaler**: Fix azure queue length ([#4002](https://github.com/kedacore/keda/issues/4002))&#xD;&#xA;- **Azure Service Bus Scaler**: Improve way clients are created to reduce amount of ARM requests ([#4262](https://github.com/kedacore/keda/issues/4262))&#xD;&#xA;- **Azure Service Bus Scaler**: Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026)|[#4123](https://github.com/kedacore/keda/issues/4123))&#xD;&#xA;- **Cassandra Scaler**: Checking whether the port information is entered in the ClusterIPAddres is done correctly. ([#4110](https://github.com/kedacore/keda/issues/4110))&#xD;&#xA;- **CPU Memory Scaler**: Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))&#xD;&#xA;- **Datadog Scaler**: Return correct error when getting a 429 error ([#4187](https://github.com/kedacore/keda/issues/4187))&#xD;&#xA;- **Kafka Scaler**: Return error if the processing of the partition lag fails ([#4098](https://github.com/kedacore/keda/issues/4098))&#xD;&#xA;- **Kafka Scaler**: Support 0 in activationLagThreshold configuration ([#4137](https://github.com/kedacore/keda/issues/4137))&#xD;&#xA;- **Kafka Scaler:** Trim whitespace from `partitionLimitation` field ([#4333](https://github.com/kedacore/keda/pull/4333))&#xD;&#xA;- **NATS Jetstream Scaler**: Fix compatibility when cluster not on kubernetes ([#4101](https://github.com/kedacore/keda/issues/4101))&#xD;&#xA;- **Prometheus Metrics**: Expose Prometheus Metrics also when getting ScaledObject state ([#4075](https://github.com/kedacore/keda/issues/4075))&#xD;&#xA;- **Redis Scalers**: Fix panic produced by incorrect logger initialization ([#4197](https://github.com/kedacore/keda/issues/4197))&#xD;&#xA;- **Selenium Grid Scaler**: ScaledObject with a trigger whose metadata browserVersion is latest is always being triggered regardless of the browserVersion requested by the user ([#4347](https://github.com/kedacore/keda/issues/4347))&#xD;&#xA;&#xD;&#xA;### Other&#xD;&#xA;&#xD;&#xA;- **General**: Bump Golang to 1.19 ([#4094](https://github.com/kedacore/keda/issues/4094))&#xD;&#xA;- **General**: Check that ScaledObject name is specified as part of a query for getting metrics ([#4088](https://github.com/kedacore/keda/pull/4088))&#xD;&#xA;- **General**: Compare error with `errors.Is` ([#4004](https://github.com/kedacore/keda/pull/4004))&#xD;&#xA;- **General**: Consolidate `GetMetrics` and `IsActive` to `GetMetricsAndActivity` for Azure Event Hub, Cron and External scalers ([#4015](https://github.com/kedacore/keda/issues/4015))&#xD;&#xA;- **General**: Improve test coverage in `pkg/util` ([#3871](https://github.com/kedacore/keda/issues/3871))&#xD;&#xA;- **General**: Metrics Server: print a message on successful connection to gRPC server ([#4190](https://github.com/kedacore/keda/issues/4190))&#xD;&#xA;- **General**: Pass deep copy object to scalers cache from the ScaledObject controller ([#4207](https://github.com/kedacore/keda/issues/4207))&#xD;&#xA;- **General**: Review CodeQL rules and enable it on PRs ([#4032](https://github.com/kedacore/keda/pull/4032))&#xD;&#xA;- **RabbitMQ Scaler:** Move from `streadway/amqp` to `rabbitmq/amqp091-go` ([#4004](https://github.com/kedacore/keda/pull/4039))&#xD;&#xA;&#xD;&#xA;### New Contributors&#xD;&#xA;&#xD;&#xA;* @dttung2905 made their first contribution in https://github.com/kedacore/keda/pull/4022&#xD;&#xA;* @Juneezee made their first contribution in https://github.com/kedacore/keda/pull/4039&#xD;&#xA;* @gifflet made their first contribution in https://github.com/kedacore/keda/pull/4105&#xD;&#xA;* @mohite-abhi made their first contribution in https://github.com/kedacore/keda/pull/4086&#xD;&#xA;* @chalokodekare made their first contribution in https://github.com/kedacore/keda/pull/4143&#xD;&#xA;* @dangerousplay made their first contribution in https://github.com/kedacore/keda/pull/4152&#xD;&#xA;* @raz-bn made their first contribution in https://github.com/kedacore/keda/pull/4047&#xD;&#xA;* @ithesadson made their first contribution in https://github.com/kedacore/keda/pull/4162&#xD;&#xA;* @sdomme made their first contribution in https://github.com/kedacore/keda/pull/4149&#xD;&#xA;* @patst made their first contribution in https://github.com/kedacore/keda/pull/4203&#xD;&#xA;* @gauron99 made their first contribution in https://github.com/kedacore/keda/pull/4223&#xD;&#xA;* @prashant-shahi made their first contribution in https://github.com/kedacore/keda/pull/4208&#xD;&#xA;* @yardenshoham made their first contribution in https://github.com/kedacore/keda/pull/4235&#xD;&#xA;* @moria97 made their first contribution in https://github.com/kedacore/keda/pull/4003&#xD;&#xA;* @mfadhlika made their first contribution in https://github.com/kedacore/keda/pull/4102&#xD;&#xA;* @shayki5 made their first contribution in https://github.com/kedacore/keda/pull/4326&#xD;&#xA;* @raggupta-ms made their first contribution in https://github.com/kedacore/keda/pull/4256&#xD;&#xA;* @AndreasBergmeier6176 made their first contribution in https://github.com/kedacore/keda/pull/4333&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/kedacore/keda/compare/v2.9.1...v2.10.0</code>
            </details>
        </details>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update keda/manifest.yaml</summary>
            <details>
                <summary>2.10.0</summary>
                <code>&#xA;Release published on the 2023-03-09 19:42:35 +0000 UTC at the url https://github.com/kedacore/keda/releases/tag/v2.10.0&#xA;&#xA;We are happy to release KEDA 2.10.0 🎉&#xD;&#xA;&#xD;&#xA;Here are some highlights:&#xD;&#xA;&#xD;&#xA;- New ArangoDB Scaler&#xD;&#xA;- New (experimental) GitHub Actions Scaler&#xD;&#xA;- New admission webhook for validating ScaledObjects&#xD;&#xA;- Security enhancements thanks to certificate integrations&#xD;&#xA;- Support for custom CAs&#xD;&#xA;&#xD;&#xA;Here are the new deprecation(s) as of this release:&#xD;&#xA;- **General**: Deprecate explicitly setting `metricName` field from `ScaledObject.triggers[*].metadata` ([#4220](https://github.com/kedacore/keda/issues/4220))&#xD;&#xA;- **Prometheus Scaler**: `cortexOrgId` metadata deprecated in favor of custom headers ([#4208](https://github.com/kedacore/keda/issues/4208))&#xD;&#xA;&#xD;&#xA;Learn how to deploy KEDA by reading [our documentation](https://keda.sh/docs/2.10/deploy/).&#xD;&#xA;&#xD;&#xA;🗓️ The next KEDA release is currently being estimated for June 13th, learn more in our [roadmap](https://github.com/kedacore/keda/blob/main/ROADMAP.md#upcoming-release-cycles).&#xD;&#xA;&#xD;&#xA;### New&#xD;&#xA;&#xD;&#xA;Here is an overview of all **stable** additions:&#xD;&#xA;&#xD;&#xA;- **General**: Add support to register custom CAs globally in KEDA operator ([#4168](https://github.com/kedacore/keda/issues/4168))&#xD;&#xA;- **General**: Introduce admission webhooks to automatically validate resource changes to prevent misconfiguration and enforce best practices ([#3755](https://github.com/kedacore/keda/issues/3755))&#xD;&#xA;- **General**: Introduce new ArangoDB Scaler ([#4000](https://github.com/kedacore/keda/issues/4000))&#xD;&#xA;- **Prometheus Metrics**: Introduce scaler activity in Prometheus metrics ([#4114](https://github.com/kedacore/keda/issues/4114))&#xD;&#xA;- **Prometheus Metrics**: Introduce scaler latency in Prometheus metrics ([#4037](https://github.com/kedacore/keda/issues/4037))&#xD;&#xA;- **Prometheus Scaler**: Extend Prometheus Scaler to support Azure managed service for Prometheus ([#4153](https://github.com/kedacore/keda/issues/4153))&#xD;&#xA;&#xD;&#xA;Here is an overview of all new **experimental** features:&#xD;&#xA;&#xD;&#xA;- **GitHub Scaler**: Introduced new GitHub Scaler (#1732)&#xD;&#xA;&#xD;&#xA;### Improvements&#xD;&#xA;&#xD;&#xA;- **General**: Add a warning when KEDA run outside supported k8s versions ([#4130](https://github.com/kedacore/keda/issues/4130))&#xD;&#xA;- **General**: Use (self-signed) certificates for all the communications (internals and externals) ([#3931](https://github.com/kedacore/keda/issues/3931))&#xD;&#xA;- **General**: Use TLS1.2 as minimum TLS version ([#4193](https://github.com/kedacore/keda/issues/4193))&#xD;&#xA;- **Azure Application Insights Scaler**: Add ignoreNullValues to ignore errors when the data returned has null in its values ([#4316](https://github.com/kedacore/keda/issues/4316))&#xD;&#xA;- **Azure Pipelines Scaler**: Improve error logging for `validatePoolID` ([#3996](https://github.com/kedacore/keda/issues/3996))&#xD;&#xA;- **Azure Pipelines Scaler**: New configuration parameter `requireAllDemands` to scale only if jobs request all demands provided by the scaling definition ([#4138](https://github.com/kedacore/keda/issues/4138))&#xD;&#xA;- **Hashicorp Vault**: Add support to secrets backend version 1 ([#2645](https://github.com/kedacore/keda/issues/2645))&#xD;&#xA;- **Kafka Scaler**: Add support to use `tls` and `sasl` in ScaledObject ([#4232](https://github.com/kedacore/keda/issues/4322))&#xD;&#xA;- **Kafka Scaler**: Improve error logging for `GetBlock` method ([#4232](https://github.com/kedacore/keda/issues/4232))&#xD;&#xA;- **Prometheus Scaler**: Add custom headers and custom auth support ([#4208](https://github.com/kedacore/keda/issues/4208))&#xD;&#xA;- **RabbitMQ Scaler**:  Add TLS support ([#967](https://github.com/kedacore/keda/issues/967))&#xD;&#xA;- **Redis Scalers**: Add support to Redis 7 ([#4052](https://github.com/kedacore/keda/issues/4052))&#xD;&#xA;- **Selenium Grid Scaler**: Add `platformName` to selenium-grid scaler metadata structure ([#4038](https://github.com/kedacore/keda/issues/4038))&#xD;&#xA;&#xD;&#xA;### Fixes&#xD;&#xA;&#xD;&#xA;- **General**: Fix regression in fallback mechanism ([#4249](https://github.com/kedacore/keda/issues/4249))&#xD;&#xA;- **General**: Prevent a panic that might occur while refreshing a scaler cache ([#4092](https://github.com/kedacore/keda/issues/4092))&#xD;&#xA;- **AWS Cloudwatch Scaler:** Make `metricName` and `namespace` optional when using `expression` ([#4334](https://github.com/kedacore/keda/issues/4262))&#xD;&#xA;- **Azure Pipelines Scaler**: Add new parameter to limit the jobs returned ([#4324](https://github.com/kedacore/keda/issues/4324))&#xD;&#xA;- **Azure Queue Scaler**: Fix azure queue length ([#4002](https://github.com/kedacore/keda/issues/4002))&#xD;&#xA;- **Azure Service Bus Scaler**: Improve way clients are created to reduce amount of ARM requests ([#4262](https://github.com/kedacore/keda/issues/4262))&#xD;&#xA;- **Azure Service Bus Scaler**: Use correct auth flows with pod identity ([#4026](https://github.com/kedacore/keda/issues/4026)|[#4123](https://github.com/kedacore/keda/issues/4123))&#xD;&#xA;- **Cassandra Scaler**: Checking whether the port information is entered in the ClusterIPAddres is done correctly. ([#4110](https://github.com/kedacore/keda/issues/4110))&#xD;&#xA;- **CPU Memory Scaler**: Store forgotten logger ([#4022](https://github.com/kedacore/keda/issues/4022))&#xD;&#xA;- **Datadog Scaler**: Return correct error when getting a 429 error ([#4187](https://github.com/kedacore/keda/issues/4187))&#xD;&#xA;- **Kafka Scaler**: Return error if the processing of the partition lag fails ([#4098](https://github.com/kedacore/keda/issues/4098))&#xD;&#xA;- **Kafka Scaler**: Support 0 in activationLagThreshold configuration ([#4137](https://github.com/kedacore/keda/issues/4137))&#xD;&#xA;- **Kafka Scaler:** Trim whitespace from `partitionLimitation` field ([#4333](https://github.com/kedacore/keda/pull/4333))&#xD;&#xA;- **NATS Jetstream Scaler**: Fix compatibility when cluster not on kubernetes ([#4101](https://github.com/kedacore/keda/issues/4101))&#xD;&#xA;- **Prometheus Metrics**: Expose Prometheus Metrics also when getting ScaledObject state ([#4075](https://github.com/kedacore/keda/issues/4075))&#xD;&#xA;- **Redis Scalers**: Fix panic produced by incorrect logger initialization ([#4197](https://github.com/kedacore/keda/issues/4197))&#xD;&#xA;- **Selenium Grid Scaler**: ScaledObject with a trigger whose metadata browserVersion is latest is always being triggered regardless of the browserVersion requested by the user ([#4347](https://github.com/kedacore/keda/issues/4347))&#xD;&#xA;&#xD;&#xA;### Other&#xD;&#xA;&#xD;&#xA;- **General**: Bump Golang to 1.19 ([#4094](https://github.com/kedacore/keda/issues/4094))&#xD;&#xA;- **General**: Check that ScaledObject name is specified as part of a query for getting metrics ([#4088](https://github.com/kedacore/keda/pull/4088))&#xD;&#xA;- **General**: Compare error with `errors.Is` ([#4004](https://github.com/kedacore/keda/pull/4004))&#xD;&#xA;- **General**: Consolidate `GetMetrics` and `IsActive` to `GetMetricsAndActivity` for Azure Event Hub, Cron and External scalers ([#4015](https://github.com/kedacore/keda/issues/4015))&#xD;&#xA;- **General**: Improve test coverage in `pkg/util` ([#3871](https://github.com/kedacore/keda/issues/3871))&#xD;&#xA;- **General**: Metrics Server: print a message on successful connection to gRPC server ([#4190](https://github.com/kedacore/keda/issues/4190))&#xD;&#xA;- **General**: Pass deep copy object to scalers cache from the ScaledObject controller ([#4207](https://github.com/kedacore/keda/issues/4207))&#xD;&#xA;- **General**: Review CodeQL rules and enable it on PRs ([#4032](https://github.com/kedacore/keda/pull/4032))&#xD;&#xA;- **RabbitMQ Scaler:** Move from `streadway/amqp` to `rabbitmq/amqp091-go` ([#4004](https://github.com/kedacore/keda/pull/4039))&#xD;&#xA;&#xD;&#xA;### New Contributors&#xD;&#xA;&#xD;&#xA;* @dttung2905 made their first contribution in https://github.com/kedacore/keda/pull/4022&#xD;&#xA;* @Juneezee made their first contribution in https://github.com/kedacore/keda/pull/4039&#xD;&#xA;* @gifflet made their first contribution in https://github.com/kedacore/keda/pull/4105&#xD;&#xA;* @mohite-abhi made their first contribution in https://github.com/kedacore/keda/pull/4086&#xD;&#xA;* @chalokodekare made their first contribution in https://github.com/kedacore/keda/pull/4143&#xD;&#xA;* @dangerousplay made their first contribution in https://github.com/kedacore/keda/pull/4152&#xD;&#xA;* @raz-bn made their first contribution in https://github.com/kedacore/keda/pull/4047&#xD;&#xA;* @ithesadson made their first contribution in https://github.com/kedacore/keda/pull/4162&#xD;&#xA;* @sdomme made their first contribution in https://github.com/kedacore/keda/pull/4149&#xD;&#xA;* @patst made their first contribution in https://github.com/kedacore/keda/pull/4203&#xD;&#xA;* @gauron99 made their first contribution in https://github.com/kedacore/keda/pull/4223&#xD;&#xA;* @prashant-shahi made their first contribution in https://github.com/kedacore/keda/pull/4208&#xD;&#xA;* @yardenshoham made their first contribution in https://github.com/kedacore/keda/pull/4235&#xD;&#xA;* @moria97 made their first contribution in https://github.com/kedacore/keda/pull/4003&#xD;&#xA;* @mfadhlika made their first contribution in https://github.com/kedacore/keda/pull/4102&#xD;&#xA;* @shayki5 made their first contribution in https://github.com/kedacore/keda/pull/4326&#xD;&#xA;* @raggupta-ms made their first contribution in https://github.com/kedacore/keda/pull/4256&#xD;&#xA;* @AndreasBergmeier6176 made their first contribution in https://github.com/kedacore/keda/pull/4333&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/kedacore/keda/compare/v2.9.1...v2.10.0</code>
            </details>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update keda/install.sh</summary>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update keda/install.sh</summary>
        </details>
    </action>
</Actions>

---

<details><summary>Updatecli options</summary>
Most of Updatecli configuration is done via Updatecli manifest.
<ul>
<li>If you close this pullrequest, Updatecli will automatically reopen it, next it runs.</li>
<li>If you close this pullrequest, and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
</ul>
</details>

---

Action triggered automatically by [Updatecli](https://www.updatecli.io).

Feel free to report any issues at [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/issues/).
If you find this tool useful, do not hesitate to star our GitHub repository [github.com/updatecli/updatecli](https://github.com/updatecli/updatecli/stargazers) as a sign of appreciation.
Or tell us directly on our [https://matrix.to/#/#Updatecli_community:gitter.im](chat)
