### PR TITLE
deps: bump cert-manager Helm chart to v1.14.5

### DIFF
--- a/cert-manager/install.sh
+++ b/cert-manager/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.5/cert-manager.yaml

--- a/cert-manager/manifest.yaml
+++ b/cert-manager/manifest.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
 title: "Cert Manager"
-version: v1.14.4
+version: v1.14.5
 maintainer: alex@openfaas.com
 description: cert-manager is a native Kubernetes certificate management controller
 url: https://cert-manager.io/docs/release-notes/release-notes-1.0/


### PR DESCRIPTION



<Actions>
    <action id="1e41e05f8755435430e624e1d0b610d8b494b5ef0ec73eef9550860eb52469e3">
        <h3>deps: bump cert-manager version</h3>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update cert-manager/manifest.yaml</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.version&#34; updated from &#34;v1.14.4&#34; to &#34;v1.14.5&#34;, in file &#34;cert-manager/manifest.yaml&#34;</p>
            <details>
                <summary>v1.14.5</summary>
                <pre>&#xA;Release published on the 2024-04-25 11:37:03 +0000 UTC at the url https://github.com/cert-manager/cert-manager/releases/tag/v1.14.5&#xA;&#xA;cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;`v1.14.5` fixes a bug in the DigitalOcean DNS-01 provider which could cause incorrect DNS records to be deleted when using a domain with a CNAME. Special thanks to @BobyMCbobs for reporting this issue and testing the fix!&#xD;&#xA;&#xD;&#xA;It also patches CVE-2023-45288.&#xD;&#xA;&#xD;&#xA;## Known Issues&#xD;&#xA;&#xD;&#xA;- ACME Issuer (Let&#39;s Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge (#6893 , @SgtCoDFish)&#xD;&#xA;- Bump golang.org/x/net to address [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) (#6931 , @SgtCoDFish)&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update cert-manager/manifest.yaml</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.version&#34; updated from &#34;v1.14.4&#34; to &#34;v1.14.5&#34;, in file &#34;cert-manager/manifest.yaml&#34;</p>
            <details>
                <summary>v1.14.5</summary>
                <pre>&#xA;Release published on the 2024-04-25 11:37:03 +0000 UTC at the url https://github.com/cert-manager/cert-manager/releases/tag/v1.14.5&#xA;&#xA;cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;`v1.14.5` fixes a bug in the DigitalOcean DNS-01 provider which could cause incorrect DNS records to be deleted when using a domain with a CNAME. Special thanks to @BobyMCbobs for reporting this issue and testing the fix!&#xD;&#xA;&#xD;&#xA;It also patches CVE-2023-45288.&#xD;&#xA;&#xD;&#xA;## Known Issues&#xD;&#xA;&#xD;&#xA;- ACME Issuer (Let&#39;s Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge (#6893 , @SgtCoDFish)&#xD;&#xA;- Bump golang.org/x/net to address [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) (#6931 , @SgtCoDFish)&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update cert-manager/manifest.yaml</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.version&#34; updated from &#34;v1.14.4&#34; to &#34;v1.14.5&#34;, in file &#34;cert-manager/manifest.yaml&#34;</p>
            <details>
                <summary>v1.14.5</summary>
                <pre>&#xA;Release published on the 2024-04-25 11:37:03 +0000 UTC at the url https://github.com/cert-manager/cert-manager/releases/tag/v1.14.5&#xA;&#xA;cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;`v1.14.5` fixes a bug in the DigitalOcean DNS-01 provider which could cause incorrect DNS records to be deleted when using a domain with a CNAME. Special thanks to @BobyMCbobs for reporting this issue and testing the fix!&#xD;&#xA;&#xD;&#xA;It also patches CVE-2023-45288.&#xD;&#xA;&#xD;&#xA;## Known Issues&#xD;&#xA;&#xD;&#xA;- ACME Issuer (Let&#39;s Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge (#6893 , @SgtCoDFish)&#xD;&#xA;- Bump golang.org/x/net to address [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) (#6931 , @SgtCoDFish)&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
        <details id="05b3abf2579a5eb66403cd78be557fd860633a1fe2103c7642030defe32c657f">
            <summary>Update cert-manager/manifest.yaml</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.version&#34; updated from &#34;v1.14.4&#34; to &#34;v1.14.5&#34;, in file &#34;cert-manager/manifest.yaml&#34;</p>
            <details>
                <summary>v1.14.5</summary>
                <pre>&#xA;Release published on the 2024-04-25 11:37:03 +0000 UTC at the url https://github.com/cert-manager/cert-manager/releases/tag/v1.14.5&#xA;&#xA;cert-manager is the easiest way to automatically manage certificates in Kubernetes and OpenShift clusters.&#xD;&#xA;&#xD;&#xA;`v1.14.5` fixes a bug in the DigitalOcean DNS-01 provider which could cause incorrect DNS records to be deleted when using a domain with a CNAME. Special thanks to @BobyMCbobs for reporting this issue and testing the fix!&#xD;&#xA;&#xD;&#xA;It also patches CVE-2023-45288.&#xD;&#xA;&#xD;&#xA;## Known Issues&#xD;&#xA;&#xD;&#xA;- ACME Issuer (Let&#39;s Encrypt): wrong certificate chain may be used if `preferredChain` is configured: see [1.14 release notes](./release-notes-1.14.md#known-issues) for more information.&#xD;&#xA;&#xD;&#xA;## Changes&#xD;&#xA;&#xD;&#xA;### Bug or Regression&#xD;&#xA;&#xD;&#xA;- DigitalOcean: Ensure that only TXT records are considered for deletion when cleaning up after an ACME challenge (#6893 , @SgtCoDFish)&#xD;&#xA;- Bump golang.org/x/net to address [CVE-2023-45288](https://nvd.nist.gov/vuln/detail/CVE-2023-45288) (#6931 , @SgtCoDFish)&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update cert-manager/install.sh</summary>
            <p>1 file(s) updated with &#34;/download/v1.14.5/&#34;:&#xA;&#x9;* cert-manager/install.sh&#xA;</p>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update cert-manager/install.sh</summary>
            <p>1 file(s) updated with &#34;/download/v1.14.5/&#34;:&#xA;&#x9;* cert-manager/install.sh&#xA;</p>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update cert-manager/install.sh</summary>
            <p>1 file(s) updated with &#34;/download/v1.14.5/&#34;:&#xA;&#x9;* cert-manager/install.sh&#xA;</p>
        </details>
        <details id="1e142e6277b12b7e1110478a24caee8f006a9349e86970c890203d6266209463">
            <summary>Update cert-manager/install.sh</summary>
            <p>1 file(s) updated with &#34;/download/v1.14.5/&#34;:&#xA;&#x9;* cert-manager/install.sh&#xA;</p>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

